### PR TITLE
Enable text-only mode for Llama4 when image limit is zero

### DIFF
--- a/tests/models/test_model_config.py
+++ b/tests/models/test_model_config.py
@@ -1,0 +1,12 @@
+import pytest
+
+from .utils import build_model_context
+
+
+@pytest.mark.parametrize("limit,is_multimodal", [(0, False), (1, True)])
+def test_is_multimodal_model_respects_limit(limit, is_multimodal):
+    ctx = build_model_context(
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+        limit_mm_per_prompt={"image": limit},
+    )
+    assert ctx.model_config.is_multimodal_model is is_multimodal

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1645,7 +1645,12 @@ class ModelConfig:
 
     @property
     def is_multimodal_model(self) -> bool:
-        return self.multimodal_config is not None
+        if self.multimodal_config is None:
+            return False
+        limits = self.multimodal_config.limit_per_prompt.values()
+        if not limits:
+            return True
+        return any(limit > 0 for limit in limits)
 
     @property
     def is_cross_encoder(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -861,6 +861,14 @@ class ModelConfig:
 
     def _init_multimodal_config(self) -> Optional["MultiModalConfig"]:
         if self._model_info.supports_multimodal:
+
+            # If all mulitmodal input limits are explicitly set to 0, then
+            # the model is treated as a text-only model.
+            if (self.limit_mm_per_prompt
+                    and all(limit == 0
+                            for limit in self.limit_mm_per_prompt.values())):
+                return None
+
             return MultiModalConfig(
                 limit_per_prompt=self.limit_mm_per_prompt,
                 media_io_kwargs=self.media_io_kwargs,
@@ -1645,12 +1653,7 @@ class ModelConfig:
 
     @property
     def is_multimodal_model(self) -> bool:
-        if self.multimodal_config is None:
-            return False
-        limits = self.multimodal_config.limit_per_prompt.values()
-        if not limits:
-            return True
-        return any(limit > 0 for limit in limits)
+        return self.multimodal_config is not None
 
     @property
     def is_cross_encoder(self) -> bool:

--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -428,20 +428,24 @@ class Mistral3ForConditionalGeneration(nn.Module, SupportsLoRA,
             config.projector_hidden_act = "gelu"
 
         # TODO: Optionally initializes this for supporting embeddings.
-        self.vision_tower = init_vision_tower_for_llava(
-            config,
-            quant_config,
-            require_post_norm=False,
-            prefix=maybe_prefix(prefix, "vision_tower"))
-        self.multi_modal_projector = Mistral3MultiModalProjector(
-            vision_hidden_size=config.vision_config.hidden_size,
-            text_hidden_size=config.text_config.hidden_size,
-            projector_hidden_act=config.projector_hidden_act,
-            spatial_merge_size=config.spatial_merge_size,
-            patch_size=config.vision_config.patch_size,
-            multimodal_projector_bias=config.multimodal_projector_bias,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "multi_modal_projector"))
+        if multimodal_config.get_limit_per_prompt("image"):
+            self.vision_tower = init_vision_tower_for_llava(
+                config,
+                quant_config,
+                require_post_norm=False,
+                prefix=maybe_prefix(prefix, "vision_tower"))
+            self.multi_modal_projector = Mistral3MultiModalProjector(
+                vision_hidden_size=config.vision_config.hidden_size,
+                text_hidden_size=config.text_config.hidden_size,
+                projector_hidden_act=config.projector_hidden_act,
+                spatial_merge_size=config.spatial_merge_size,
+                patch_size=config.vision_config.patch_size,
+                multimodal_projector_bias=config.multimodal_projector_bias,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "multi_modal_projector"))
+        else:
+            self.vision_tower = None
+            self.multi_modal_projector = None
 
         self.language_model = init_vllm_registered_model(
             vllm_config=vllm_config,
@@ -611,7 +615,11 @@ class Mistral3ForConditionalGeneration(nn.Module, SupportsLoRA,
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        skip_prefixes = []
+        if self.vision_tower is None and self.multi_modal_projector is None:
+            skip_prefixes = ["vision_tower.", "multi_modal_projector."]
+
+        loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
     def get_mm_mapping(self) -> MultiModelKeys:

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -737,8 +737,7 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         self.config = config
         self.quant_config = quant_config
         self.multimodal_config = multimodal_config
-        max_images = multimodal_config.get_limit_per_prompt("image")
-        if max_images > 0:
+        if multimodal_config.get_limit_per_prompt("image"):
             self.vision_model = Llama4VisionModel(
                 config.vision_config,
                 None,
@@ -788,9 +787,8 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
 
     def _process_image_input(
             self, image_input: Llama4ImagePatchInputs) -> MultiModalEmbeddings:
-        if self.vision_model is None or self.multi_modal_projector is None:
-            raise RuntimeError("Image inputs are disabled.")
 
+        assert self.vision_model and self.multi_modal_projector
         flat_data = image_input["flat_data"]
         patches_per_image = image_input["patches_per_image"].tolist()
 
@@ -1054,10 +1052,14 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Separate and rename weights
         language_model_weights, other_weights = (
             self._separate_and_rename_weights(weights))
+
+        # Skip loading vision model and projector if they're not initialized.
         if self.vision_model is None and self.multi_modal_projector is None:
-            other_weights = [(name, weight) for name, weight in other_weights
-                             if not (name.startswith("vision_model.") or
-                                     name.startswith("multi_modal_projector."))]
+            other_weights = [
+                (name, weight) for name, weight in other_weights
+                if not (name.startswith("vision_model.")
+                        or name.startswith("multi_modal_projector."))
+            ]
 
         # Handle expert scale parameters
         regular_weights, expert_scale_weights, updated_params_from_experts = (

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -737,16 +737,21 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         self.config = config
         self.quant_config = quant_config
         self.multimodal_config = multimodal_config
-        self.vision_model = Llama4VisionModel(
-            config.vision_config,
-            None,
-            prefix=maybe_prefix(prefix, "vision_model"),
-            use_data_parallel=self.use_data_parallel,
-        )
-        self.multi_modal_projector = Llama4MultiModalProjector(
-            self.config,
-            None,
-            prefix=maybe_prefix(prefix, "multi_modal_projector"))
+        max_images = multimodal_config.get_limit_per_prompt("image")
+        if max_images > 0:
+            self.vision_model = Llama4VisionModel(
+                config.vision_config,
+                None,
+                prefix=maybe_prefix(prefix, "vision_model"),
+                use_data_parallel=self.use_data_parallel,
+            )
+            self.multi_modal_projector = Llama4MultiModalProjector(
+                self.config,
+                None,
+                prefix=maybe_prefix(prefix, "multi_modal_projector"))
+        else:
+            self.vision_model = None
+            self.multi_modal_projector = None
         self.language_model = initialize_model(
             vllm_config=vllm_config.with_hf_config(config.text_config,
                                                    ["LlamaForCausalLM"]),
@@ -783,6 +788,9 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
 
     def _process_image_input(
             self, image_input: Llama4ImagePatchInputs) -> MultiModalEmbeddings:
+        if self.vision_model is None or self.multi_modal_projector is None:
+            raise RuntimeError("Image inputs are disabled.")
+
         flat_data = image_input["flat_data"]
         patches_per_image = image_input["patches_per_image"].tolist()
 
@@ -1046,6 +1054,10 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Separate and rename weights
         language_model_weights, other_weights = (
             self._separate_and_rename_weights(weights))
+        if self.vision_model is None and self.multi_modal_projector is None:
+            other_weights = [(name, weight) for name, weight in other_weights
+                             if not (name.startswith("vision_model.") or
+                                     name.startswith("multi_modal_projector."))]
 
         # Handle expert scale parameters
         regular_weights, expert_scale_weights, updated_params_from_experts = (


### PR DESCRIPTION
## Summary
- skip vision model and projector when `--limit-mm-per-prompt {"image":0}` enabling text-only inference
- treat model as non-multimodal when all modality limits are zero
- add regression test for multimodal limit handling

## Testing
- `pre-commit run --files vllm/model_executor/models/mllama4.py vllm/config.py tests/models/test_model_config.py` *(fails: pre-commit not installed, 403 when installing)*
- `pytest tests/models/test_model_config.py` *(fails: torch missing, 403 when installing)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab31bc988324a0bb8b8d8ba11c87